### PR TITLE
Enables Foundry VTT v11 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -34,8 +34,8 @@
     ]
   },
   "url": "https://github.com/Foxfyre/the-expanse-quickstart",
-  "manifest": "https://github.com/ieuanmeredith/the-expanse-quickstart/releases/latest/download/module.json",
-  "download": "https://github.com/ieuanmeredith/the-expanse-quickstart/releases/download/1.2.0/the-expanse-quickstart.zip",
+  "manifest": "https://github.com/Foxfyre/the-expanse-quickstart/releases/latest/download/module.json",
+  "download": "https://github.com/Foxfyre/the-expanse-quickstart/releases/download/1.2.0/the-expanse-quickstart.zip",
   "relationships": {
     "systems": [
       {

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "the-expanse-quickstart",
   "title": "The Expanse Quickstart",
   "description": "The quickstart for The Expanse by Green Ronin. This Module contains everything you need to run your first game of The Expanse. The Expanse system is required for this module to function",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "authors": [
     {
       "name": "Foxfyre",
@@ -22,7 +22,7 @@
     {
       "label": "The Expanse Quickstart",
       "name": "the-expanse-quickstart",
-      "path": "packs/the-expanse-quickstart.db",
+      "path": "packs/the-expanse-quickstart",
       "system": "expanse",
       "type": "Adventure",
       "private": false,
@@ -34,8 +34,8 @@
     ]
   },
   "url": "https://github.com/Foxfyre/the-expanse-quickstart",
-  "manifest": "https://github.com/Foxfyre/the-expanse-quickstart/releases/latest/download/module.json",
-  "download": "https://github.com/Foxfyre/the-expanse-quickstart/releases/download/1.1.1/the-expanse-quickstart.zip",
+  "manifest": "https://github.com/ieuanmeredith/the-expanse-quickstart/releases/latest/download/module.json",
+  "download": "https://github.com/ieuanmeredith/the-expanse-quickstart/releases/download/1.2.0/the-expanse-quickstart.zip",
   "relationships": {
     "systems": [
       {
@@ -48,6 +48,6 @@
   "compatibility": {
     "minimum": "10",
     "verified": "10.291",
-    "maximum": "10"
+    "maximum": "11"
   }
 }


### PR DESCRIPTION
Changes made inline with [https://foundryvtt.com/article/v11-leveldb-packs/](https://foundryvtt.com/article/v11-leveldb-packs/) 

Tested against a fork of The Expanse game system with v11 compatibility changes. Looks to all work but I'm not intimately familiar with the system

Can be tested against V11 Foundry via [https://github.com/ieuanmeredith/the-expanse-quickstart/releases/download/1.2.0/module.json](https://github.com/ieuanmeredith/the-expanse-quickstart/releases/download/1.2.0/module.json)